### PR TITLE
x[#] should work now...

### DIFF
--- a/Korn.g4
+++ b/Korn.g4
@@ -128,7 +128,7 @@ variable:
 ;
 
 arrayElement:
-    arrayname=Identifier OpenBracket arrayindex=NonZeroDigit CloseBracket
+    arrayname=Identifier OpenBracket arrayindex=DigitSequence CloseBracket
 ;
 
 expression:
@@ -153,12 +153,8 @@ assignmentExpression:
 assignmentRightOperand:
     variable
     | value
-    | expression
-    | subprogramCall
-    | relationalExpression
     | arithmeticExpression
-    | logicalExpression
-    | equalityExpression
+    | subprogramCall
 ;
 
 logicalExpression:
@@ -266,10 +262,10 @@ Separator:              ',';
 End:                    'end';
 DigitSequence:          Digit+;
 Digit:                  Zero | NonZeroDigit;
+NonZeroDigit:           [1-9];
 RecordMemberOperator:   Dot;
 Identifier:             NonDigitCharacter CharacterSequence*;
 StringLiteral:          ('"' ( '\\' [\\"] | ~[\\"] )* '"') | ('\'' ( '\\' [\\"] | ~[\\"] )* '\'');
-NonZeroDigit:           [1-9];
 Zero:                   [0];
 NonDigitCharacter:      [a-zA-Z_];
 Dot:                    '.';


### PR DESCRIPTION
'Twas lexed as a digit sequence first and so was not lexed as a nonzerodigit leading to errors.

Updated assignmentRightOperand to not include stuff 

but x[/*arithmetic expression*/] does not work here