### PR TITLE
Updated blocks to not need an empty line after

### DIFF
--- a/Korn.g4
+++ b/Korn.g4
@@ -13,7 +13,7 @@ taskBlock:
 ;
 
 blockEnd:
-    End (NEWLINE+ | EOF)
+    End
 ;
 
 returnStatement:


### PR DESCRIPTION
With "(NEWLINE+| EOF)" inside blockEnd it requires an empty line after the end keyword.

Removed "(NEWLINE+| EOF)" from blockEnd since statement already handles "(NEWLINE+| EOF)".