### PR TITLE
Minor fixes

### DIFF
--- a/Korn.g4
+++ b/Korn.g4
@@ -154,12 +154,14 @@ assignmentRightOperand:
     variable
     | value
     | arithmeticExpression
+    | relationalExpression
+    | logicalExpression
     | subprogramCall
 ;
 
 logicalExpression:
     (booleanValue | variable) (operator=LogicalOperator (booleanValue | variable))+
-    | (operator=LogicalOperatorNot (booleanValue | variable))+
+    | (operator=LogicalOperatorNot (booleanValue | variable))
 ;
 
 equalityExpression:
@@ -217,7 +219,7 @@ number:
 ;
 
 decimal:
-    wholenumber=DigitSequence Dot decimalvalue=DigitSequence
+    wholenumber=DigitSequence RecordMemberOperator decimalvalue=DigitSequence
 ;
 
 identifier:
@@ -251,7 +253,7 @@ WhileKeyword:           'while';
 ForEachKeyword:         'for each';
 RunKeyword:             'run';
 ArrayIteratorKeyword:   'in';
-RecordKeyword:          'Box';
+RecordKeyword:          'box';
 ReturnKeyword:          'return';
 OpenBracket:            '[';
 CloseBracket:           ']';


### PR DESCRIPTION
assignmentRightOperand:
    | relationalExpression
    | logicalExpression
> added relational and logical expressions

logicalExpression:
    | (operator=LogicalOperatorNot (booleanValue | variable))
> removed + kae if naa ma.accept ang `not a not b`

decimal:
    wholenumber=DigitSequence RecordMemberOperator decimalvalue=DigitSequence
> error ang `Dot` instead of `RecordMemberOperator`

'box';
> small b sa doc for uniformity purposes